### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BIObjCHelpers
 
 Collection of Objective C helpers
 
-[![Build Status](https://travis-ci.org/grigaci/BIObjCHelpers.svg?branch=master)](https://travis-ci.org/grigaci/BIObjCHelpers) [![Coverage Status](https://coveralls.io/repos/grigaci/BIObjCHelpers/badge.png?branch=master)](https://coveralls.io/r/grigaci/BIObjCHelpers?branch=master) [![Cocoapods Version](https://cocoapod-badges.herokuapp.com/v/BIObjCHelpers/badge.png)](http://cocoapods.org/?q=BIObjCHelpers)
+[![Build Status](https://travis-ci.org/grigaci/BIObjCHelpers.svg?branch=master)](https://travis-ci.org/grigaci/BIObjCHelpers) [![Coverage Status](https://coveralls.io/repos/grigaci/BIObjCHelpers/badge.png?branch=master)](https://coveralls.io/r/grigaci/BIObjCHelpers?branch=master) [![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/BIObjCHelpers/badge.png)](http://cocoapods.org/?q=BIObjCHelpers)
 
 # Build
 Use Xcode 7.2 or above for building the projects.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
